### PR TITLE
API Token in env-variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ core.*
 docs/_build/
 
 _version.py
+.gitpod.yml

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Synoptic data access is [_free_](https://synopticdata.com/news/2022/3/15/synopti
 
 I wrote these functions to conveniently access data from the Synoptic API and convert the JSON data to a **[Pandas DataFrame](https://pandas.pydata.org/docs/)**. This may be helpful to others who are getting started with the Synoptic API and Python. The idea is loosely based on the obsolete [MesoPy](https://github.com/mesowx/MesoPy) python wrapper, but returning the data as a Pandas DataFrame instead of a simple dictionary, making the retrieved data more _ready-to-use_.
 
-- [👨🏻‍🏭 Contributing Guidelines and Disclaimer](https://synopticpy.readthedocs.io/user_guide/contribute.html)
+- [👨🏻‍🏭 Contributing Guidelines and Disclaimer](https://synopticpy.readthedocs.io/en/latest/user_guide/contribute.html)
 - [💬 Discussions](https://github.com/blaylockbk/SynopticPy/discussions)
 - [🐛 Issues](https://github.com/blaylockbk/SynopticPy/issues)
 
@@ -90,7 +90,7 @@ pip install SynopticPy
 
 # 🔨 Setup
 
-After following the setup instructions in the [documentation](https://synopticpy.readthedocs.io/user_guide/setup.html), you should have a file at `~/.config/SynopticPy/config.toml` that looks something like this:
+After following the setup instructions in the [documentation](https://synopticpy.readthedocs.io/en/latest/user_guide/setup.html), you should either have an environmental variable named `SYNOPTIC_TOKEN` or a file at `~/.config/SynopticPy/config.toml` that looks something like this:
 
 ```
 [default]
@@ -107,8 +107,8 @@ you will be prompted to update the token in the config file.
 
 # Quick Examples
 
-- [User Guide Examples](https://synopticpy.readthedocs.io/user_guide/examples.html)
-- [Reference Guide](https://synopticpy.readthedocs.io/reference_guide/index.html)
+- [User Guide Examples](https://synopticpy.readthedocs.io/en/latest/user_guide/examples.html)
+- [Reference Guide](https://synopticpy.readthedocs.io/en/latest/reference_guide/index.html)
 - [Jupyter Notebooks](https://github.com/blaylockbk/SynopticPy/tree/main/notebooks)
 
 > TODO: Move these notebooks to the docs.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ conda env update -f environment.yml
 
 ## Option 2: pip
 
-Install the last published version from PyPI. This requires the following are already installed:  
-`numpy`, `pandas`, `requests`, and `toml`. It's optional, but you will likely want `matplotlib`, and `cartopy`, too.
+Install the last published version from PyPI. It's optional, but you will likely want `cartopy` too.
 
 ```bash
 pip install SynopticPy

--- a/docs/user_guide/setup.rst
+++ b/docs/user_guide/setup.rst
@@ -28,7 +28,17 @@ SynopticPy needs to know your token. The first time you import ``synoptic.servic
 
 3. The script updates a config file located at ``~/.config/SynopticPy/config.toml``. 
     
-Every time you import a ``synoptic.services`` function it does a quick check to make sure the token in that file is valid. If everything looks good, the next time you import the module you won't be asked for the token because it is saved in that config file.
+
+Alternatively you can store the token in the environmental variable named  ``SYNOPTIC_TOKEN``.
+
+To do so open your terminal and type: 
+.. code-block:: bash
+
+    export SYNOPTIC_TOKEN=yourtoken1234567890jklmnopqrstuvwxyz
+
+This way, the default settings will be applied for the configuration. If a configuration file exist, the values will be overwritten.
+
+Every time you import a ``synoptic.services`` function it does a quick check to make sure the token is valid. If everything looks good, the next time you import the module you won't be asked for the token because it is saved in that config file or in the environmental variable.
 
 Configure Settings
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     pandas
     requests
     toml
+    matplotlib
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     pandas
     requests
     toml
-    carpenter-workshop @ git+https://github.com/blaylockbk/Carpenter_Workshop.git
 
 [options.extras_require]
 docs =

--- a/synoptic/get_token.py
+++ b/synoptic/get_token.py
@@ -63,7 +63,6 @@ default_config = {
 
 # get token from environment variable if available
 env_token = os.environ.get("SYNOPTIC_TOKEN")
-print("token:", env_token)
 
 ########################################################################
 # If a config file isn't found, make one

--- a/synoptic/get_token.py
+++ b/synoptic/get_token.py
@@ -51,9 +51,23 @@ rename_value_1 = true
 rename_set_1 = true
 """
 
+# Default configuration, used when the API token is stored in an environmental variable
+default_config = {
+    "default": {
+        "verbose": True,
+        "hide_token": True,
+        "rename_value_1": True,
+        "rename_set_1": True,
+    }
+}
+
+# get token from environment variable if available
+env_token = os.environ.get("SYNOPTIC_TOKEN")
+print("token:", env_token)
+
 ########################################################################
 # If a config file isn't found, make one
-if not _config_path.exists():
+if not _config_path.exists() and not env_token:
     print(
         f" ╭─────────────────────────────────────────────────╮\n"
         f" │ I'm building SynopticPy's default config file.  │\n"
@@ -103,7 +117,7 @@ def test_token(verbose=True, configure_on_fail=True):
     configure_on_fail : bool
 
         - True: Help the user update the config file with ``config_token``
-        - False: Do not update (prevents infinant loop if user keeps adding an invalid token).
+        - False: Do not update (prevents infinite loop if user keeps adding an invalid token).
 
     verbose : bool
 
@@ -115,9 +129,14 @@ def test_token(verbose=True, configure_on_fail=True):
     A valid API token
 
     """
-    # Read the config file and get the token
-    config = toml.load(_config_path)
-    token = config["default"].get("token")
+    # If the token is not stored in an environmental variable, read the config file and get the token
+    if env_token:
+        config = default_config
+        config["default"]["token"] = env_token
+        token = env_token
+    else:
+        config = toml.load(_config_path)
+        token = config["default"].get("token")
 
     if token is None:
         # There isn't an API token defined, so configure one.
@@ -187,7 +206,7 @@ def config_token(new_token=None):
 
     print(f"\nThanks! I will do a quick test...")
 
-    # Don't want to run into an infinite loop, so set config_on_fail=False
+    # Don't want to run into an infinite loop, so set configure_on_fail=False
     config = test_token(configure_on_fail=False)
     return config
 


### PR DESCRIPTION
- Added the possibility to store the API-Token in an environmental-variable.
- Added the description on how to do it to the readme/documentation
- fixed some typos and dead links

solves this Issue: #13