### PR TITLE
Added method to write ascii file for MET's ASCII2NC tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,6 @@ node_modules
 dev
 app
 
+# Sample files and data
 sample_*
+sample_ascii_for_met.txt

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ conda install -c conda-forge synopticpy
 
 > [!IMPORTANT]
 >
-> ## 🎟️ You need a Synoptic API token before using SynopticPy. [Register for a FREE Synoptic account now](https://customer.synopticdata.com/).
+> ## 🎟️ To use SynopticPy you need a [Synoptic API token](https://customer.synopticdata.com/).
 
 There are three ways you can configure your Synoptic API token:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,8 +47,7 @@ I'm a Synoptic user. I wrote this package to conveniently request data from Syno
 
 
 .. important::
-   🎟️ You need a Synoptic API token before using SynopticPy. `Register for a free Synoptic account
-   <https://customer.synopticdata.com/signup-targeted/?signup=open-access>`_.
+   🎟️ To use SynopticPy you need a `Synoptic API token <https://customer.synopticdata.com/signup-targeted/?signup=open-access>`_.
 
 I'm sharing this package to improve my skills with Polars and gain more experience in building and maintaining open-source Python packages. If you are using Synoptic's API and came across this package, I hope you find it useful.
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -10,6 +10,13 @@ def test_with_network_name():
     assert "network_name" in df.columns
     assert len(df)
 
+
 def test_with_local_timezone():
     df = TimeSeries(stid="wbb", recent=30).df()
     df = df.synoptic.with_local_timezone()
+
+
+def test_write_met():
+    """Writing output for MET's ASCII2NC tool."""
+    df = TimeSeries(stid="ubkbk,wbb", recent=60).df()
+    df.synoptic.write_met("sample_ascii_for_met.txt")


### PR DESCRIPTION
Added a polars synoptic namespace method to write DataFrame to a 11-column ASCII file that can be used by the [Model Evaluation Tools (MET)](https://[dtcenter.org](https://dtcenter.org/community-code/model-evaluation-tools-met)/community-code/model-evaluation-tools-met) [ASCII2NC](https://met.readthedocs.io/en/latest/Users_Guide/reformat_point.html#ascii2nc-tool) tool.

```python
from synoptic import TimeSeries
df = TimeSeries(stid="ubkbk,wbb", recent=60).df()
df.synoptic.write_met("sample_ascii_for_met.txt")
```

Description of the file format:        https://met.readthedocs.io/en/latest/Users_Guide/reformat_point.html#ascii2nc-tool

Sample File        https://github.com/dtcenter/MET/blob/main_v11.1/data/sample_obs/ascii/sample_ascii_obs_varname.txt

> ⚠️**WARNING**: I haven't actually tested that the file it writes can be used by MET's ASCII2NC tool. This is primarily a proof of concept. Please open a PR if you want to see this feature improved and tested.